### PR TITLE
Fix checksum of the 4.1.1 ubuntu ee version

### DIFF
--- a/defaults/Ubuntu.yml
+++ b/defaults/Ubuntu.yml
@@ -23,7 +23,7 @@
 couchbase_server_ubuntu_ee_version: 4.1.1
 couchbase_server_ubuntu_ee_package: couchbase-server-enterprise_{{ couchbase_server_ubuntu_ee_version }}-ubuntu14.04_amd64.deb
 couchbase_server_ubuntu_ee_url: http://packages.couchbase.com/releases/{{ couchbase_server_ubuntu_ee_version }}/{{ couchbase_server_ubuntu_ee_package }}
-couchbase_server_ubuntu_ee_sha256: 7bf1ea386669cb3e3050550d76288156970621b5eba9f1ed1ca92b8a9e5f620c
+couchbase_server_ubuntu_ee_sha256: 65c0ee37f0e6d816257b32a36207ec9b8e81c84112beb657c851f9aacb9b4382
 
 # couchbase_server_ubuntu_ee_version: 4.1.0
 # couchbase_server_ubuntu_ee_package: couchbase-server-enterprise_{{ couchbase_server_ubuntu_ee_version }}-ubuntu14.04_amd64.deb


### PR DESCRIPTION
We tried to use the updated version of the ansible script to deploy the last 4.1.1 enterprise version on Ubuntu and it seems the sha256 checksum is not right

Are we wrong?

