### PR TITLE
Update enterprise and community versions

### DIFF
--- a/defaults/CentOS.yml
+++ b/defaults/CentOS.yml
@@ -101,16 +101,15 @@ couchbase_server_centos_ee_sha256: 175efc154650130bc53f8b5cbced1578994f6be6dd7f9
 #
 #############################################################################
 
-# 4.1.0 Developer Preview
-# couchbase_server_centos_ce_version: 4.1.0
-# couchbase_server_centos_ce_package: couchbase-server-{{ couchbase_server_centos_ce_version }}-dp-centos7.x86_64.rpm
-# couchbase_server_centos_ce_url: http://packages.couchbase.com/releases/{{ couchbase_server_centos_ce_version }}/{{ couchbase_server_centos_ce_package }}
-# couchbase_server_centos_ce_sha256: 97ecbc367af59a67f9ee3a449683c9c1a52fdc3d9576efe2da88e01ea3f67ae6
-
-couchbase_server_centos_ce_version: 4.0.0
+couchbase_server_centos_ce_version: 4.1.1
 couchbase_server_centos_ce_package: couchbase-server-community-{{ couchbase_server_centos_ce_version }}-centos6.x86_64.rpm
 couchbase_server_centos_ce_url: http://packages.couchbase.com/releases/{{ couchbase_server_centos_ce_version }}/{{ couchbase_server_centos_ce_package }}
-couchbase_server_centos_ce_sha256: 73f048e49617095e6a0cb9a82f74578d48b1054e8142fb712eab71395d7b9ce0
+couchbase_server_centos_ce_sha256: 64e87b70ca1e28f4ff7b9d9bfcad3337b7577a744d5b4363db9189df45e6bf81
+
+# couchbase_server_centos_ce_version: 4.0.0
+# couchbase_server_centos_ce_package: couchbase-server-community-{{ couchbase_server_centos_ce_version }}-centos6.x86_64.rpm
+# couchbase_server_centos_ce_url: http://packages.couchbase.com/releases/{{ couchbase_server_centos_ce_version }}/{{ couchbase_server_centos_ce_package }}
+# couchbase_server_centos_ce_sha256: 73f048e49617095e6a0cb9a82f74578d48b1054e8142fb712eab71395d7b9ce0
 
 # couchbase_server_centos_ce_version: 3.0.1
 # couchbase_server_centos_ce_package: couchbase-server-community-{{ couchbase_server_centos_ce_version }}-centos6.x86_64.rpm

--- a/defaults/CentOS.yml
+++ b/defaults/CentOS.yml
@@ -25,10 +25,15 @@
 
 #### CentOS 7 now by default
 
-couchbase_server_centos_ee_version: 4.1.1
+couchbase_server_centos_ee_version: 4.5.1
 couchbase_server_centos_ee_package: couchbase-server-enterprise-{{ couchbase_server_centos_ee_version }}-centos7.x86_64.rpm
 couchbase_server_centos_ee_url: http://packages.couchbase.com/releases/{{ couchbase_server_centos_ee_version }}/{{ couchbase_server_centos_ee_package }}
-couchbase_server_centos_ee_sha256: 057636313e7087adc040b8f0bc2425dfdcae5a0cb2a598b50ce5bdfc67d9325d
+couchbase_server_centos_ee_sha256: 175efc154650130bc53f8b5cbced1578994f6be6dd7f9c299230090fd17e0343
+
+# couchbase_server_centos_ee_version: 4.1.1
+# couchbase_server_centos_ee_package: couchbase-server-enterprise-{{ couchbase_server_centos_ee_version }}-centos7.x86_64.rpm
+# couchbase_server_centos_ee_url: http://packages.couchbase.com/releases/{{ couchbase_server_centos_ee_version }}/{{ couchbase_server_centos_ee_package }}
+# couchbase_server_centos_ee_sha256: 057636313e7087adc040b8f0bc2425dfdcae5a0cb2a598b50ce5bdfc67d9325d
 
 # couchbase_server_centos_ee_version: 4.1.0
 # couchbase_server_centos_ee_package: couchbase-server-enterprise-{{ couchbase_server_centos_ee_version }}-centos7.x86_64.rpm

--- a/defaults/Debian.yml
+++ b/defaults/Debian.yml
@@ -99,16 +99,15 @@ couchbase_server_debian_ee_sha256: 5191e4bf2226d6f8b9828c1f09911cb91766ef70e1943
 #
 #############################################################################
 
-# 4.1.0 Developer Preview
-# couchbase_server_debian_ce_version: 4.1.0
-# couchbase_server_debian_ce_package: couchbase-server_{{ couchbase_server_debian_ce_version }}-dp-debian7_amd64.deb
-# couchbase_server_debian_ce_url: http://packages.couchbase.com/releases/{{ couchbase_server_debian_ce_version }}/{{ couchbase_server_debian_ce_package }}
-# couchbase_server_debian_ce_sha256: be371bdfc27820f4f52f26908c8ad69de89a2d181328770bcbb3378537839c3c
-
-couchbase_server_debian_ce_version: 4.0.0
+couchbase_server_debian_ce_version: 4.1.1
 couchbase_server_debian_ce_package: couchbase-server-community_{{ couchbase_server_debian_ce_version }}-debian7_amd64.deb
 couchbase_server_debian_ce_url: http://packages.couchbase.com/releases/{{ couchbase_server_debian_ce_version }}/{{ couchbase_server_debian_ce_package }}
-couchbase_server_debian_ce_sha256: 1fb8961e54b0e4a9d1fc2efc925b82054281abf3c520294311d874e66d78cf6e
+couchbase_server_debian_ce_sha256: 1a18f239b1bbac65edbb1a00f911055fb55361431e6241002b0f492dbcfac938
+
+# couchbase_server_debian_ce_version: 4.0.0
+# couchbase_server_debian_ce_package: couchbase-server-community_{{ couchbase_server_debian_ce_version }}-debian7_amd64.deb
+# couchbase_server_debian_ce_url: http://packages.couchbase.com/releases/{{ couchbase_server_debian_ce_version }}/{{ couchbase_server_debian_ce_package }}
+# couchbase_server_debian_ce_sha256: 1fb8961e54b0e4a9d1fc2efc925b82054281abf3c520294311d874e66d78cf6e
 
 # couchbase_server_debian_ce_version: 3.0.1
 # couchbase_server_debian_ce_package: couchbase-server-community_{{ couchbase_server_debian_ce_version }}-debian7_amd64.deb

--- a/defaults/Debian.yml
+++ b/defaults/Debian.yml
@@ -23,10 +23,15 @@
 #
 #############################################################################
 
-couchbase_server_debian_ee_version: 4.1.1
+couchbase_server_debian_ee_version: 4.5.1
 couchbase_server_debian_ee_package: couchbase-server-enterprise_{{ couchbase_server_debian_ee_version }}-debian7_amd64.deb
 couchbase_server_debian_ee_url: http://packages.couchbase.com/releases/{{ couchbase_server_debian_ee_version }}/{{ couchbase_server_debian_ee_package }}
-couchbase_server_debian_ee_sha256: 1d084294ae257e2a3592268afedd27d0d31c51b5e5957c178ba571f3e43734ad
+couchbase_server_debian_ee_sha256: 5191e4bf2226d6f8b9828c1f09911cb91766ef70e194384c527afbbc812668bf
+
+# couchbase_server_debian_ee_version: 4.1.1
+# couchbase_server_debian_ee_package: couchbase-server-enterprise_{{ couchbase_server_debian_ee_version }}-debian7_amd64.deb
+# couchbase_server_debian_ee_url: http://packages.couchbase.com/releases/{{ couchbase_server_debian_ee_version }}/{{ couchbase_server_debian_ee_package }}
+# couchbase_server_debian_ee_sha256: 1d084294ae257e2a3592268afedd27d0d31c51b5e5957c178ba571f3e43734ad
 
 # couchbase_server_debian_ee_version: 4.1.0
 # couchbase_server_debian_ee_package: couchbase-server-enterprise_{{ couchbase_server_debian_ee_version }}-debian7_amd64.deb

--- a/defaults/RedHat.yml
+++ b/defaults/RedHat.yml
@@ -25,10 +25,15 @@
 
 #### RHEL 7 now by default
 
-couchbase_server_centos_ee_version: 4.1.1
+couchbase_server_centos_ee_version: 4.5.1
 couchbase_server_centos_ee_package: couchbase-server-enterprise-{{ couchbase_server_centos_ee_version }}-centos7.x86_64.rpm
 couchbase_server_centos_ee_url: http://packages.couchbase.com/releases/{{ couchbase_server_centos_ee_version }}/{{ couchbase_server_centos_ee_package }}
-couchbase_server_centos_ee_sha256: 057636313e7087adc040b8f0bc2425dfdcae5a0cb2a598b50ce5bdfc67d9325d
+couchbase_server_centos_ee_sha256: 175efc154650130bc53f8b5cbced1578994f6be6dd7f9c299230090fd17e0343
+
+# couchbase_server_centos_ee_version: 4.1.1
+# couchbase_server_centos_ee_package: couchbase-server-enterprise-{{ couchbase_server_centos_ee_version }}-centos7.x86_64.rpm
+# couchbase_server_centos_ee_url: http://packages.couchbase.com/releases/{{ couchbase_server_centos_ee_version }}/{{ couchbase_server_centos_ee_package }}
+# couchbase_server_centos_ee_sha256: 057636313e7087adc040b8f0bc2425dfdcae5a0cb2a598b50ce5bdfc67d9325d
 
 # couchbase_server_centos_ee_version: 4.1.0
 # couchbase_server_centos_ee_package: couchbase-server-enterprise-{{ couchbase_server_centos_ee_version }}-centos7.x86_64.rpm

--- a/defaults/RedHat.yml
+++ b/defaults/RedHat.yml
@@ -101,16 +101,15 @@ couchbase_server_centos_ee_sha256: 175efc154650130bc53f8b5cbced1578994f6be6dd7f9
 #
 #############################################################################
 
-# 4.1.0 Developer Preview
-# couchbase_server_centos_ce_version: 4.1.0
-# couchbase_server_centos_ce_package: couchbase-server-{{ couchbase_server_centos_ce_version }}-dp-centos7.x86_64.rpm
-# couchbase_server_centos_ce_url: http://packages.couchbase.com/releases/{{ couchbase_server_centos_ce_version }}/{{ couchbase_server_centos_ce_package }}
-# couchbase_server_centos_ce_sha256: 97ecbc367af59a67f9ee3a449683c9c1a52fdc3d9576efe2da88e01ea3f67ae6
-
-couchbase_server_centos_ce_version: 4.0.0
+couchbase_server_centos_ce_version: 4.1.1
 couchbase_server_centos_ce_package: couchbase-server-community-{{ couchbase_server_centos_ce_version }}-centos6.x86_64.rpm
 couchbase_server_centos_ce_url: http://packages.couchbase.com/releases/{{ couchbase_server_centos_ce_version }}/{{ couchbase_server_centos_ce_package }}
-couchbase_server_centos_ce_sha256: 73f048e49617095e6a0cb9a82f74578d48b1054e8142fb712eab71395d7b9ce0
+couchbase_server_centos_ce_sha256: 64e87b70ca1e28f4ff7b9d9bfcad3337b7577a744d5b4363db9189df45e6bf81
+
+# couchbase_server_centos_ce_version: 4.0.0
+# couchbase_server_centos_ce_package: couchbase-server-community-{{ couchbase_server_centos_ce_version }}-centos6.x86_64.rpm
+# couchbase_server_centos_ce_url: http://packages.couchbase.com/releases/{{ couchbase_server_centos_ce_version }}/{{ couchbase_server_centos_ce_package }}
+# couchbase_server_centos_ce_sha256: 73f048e49617095e6a0cb9a82f74578d48b1054e8142fb712eab71395d7b9ce0
 
 # couchbase_server_centos_ce_version: 3.0.1
 # couchbase_server_centos_ce_package: couchbase-server-community-{{ couchbase_server_centos_ce_version }}-centos6.x86_64.rpm

--- a/defaults/Ubuntu.yml
+++ b/defaults/Ubuntu.yml
@@ -96,16 +96,15 @@ couchbase_server_ubuntu_ee_sha256: 4e9075643a46c015acd2dbb5c7d6c047904b21c1934f4
 #
 #############################################################################
 
-# 4.1.0 Developer Preview
-# couchbase_server_ubuntu_ce_version: 4.1.0
-# couchbase_server_ubuntu_ce_package: couchbase-server_{{ couchbase_server_ubuntu_ce_version }}-dp-ubuntu14.04_amd64.deb
-# couchbase_server_ubuntu_ce_url: http://packages.couchbase.com/releases/{{ couchbase_server_ubuntu_ce_version }}/{{ couchbase_server_ubuntu_ce_package }}
-# couchbase_server_ubuntu_ce_sha256: 6ed9557f1d81d70e4a5559d8235b9cb63e00b156e3173ef0a9b08aa66179ea0f
-
-couchbase_server_ubuntu_ce_version: 4.0.0
+couchbase_server_ubuntu_ce_version: 4.1.1
 couchbase_server_ubuntu_ce_package: couchbase-server-community_{{ couchbase_server_ubuntu_ce_version }}-ubuntu14.04_amd64.deb
 couchbase_server_ubuntu_ce_url: http://packages.couchbase.com/releases/{{ couchbase_server_ubuntu_ce_version }}/{{ couchbase_server_ubuntu_ce_package }}
-couchbase_server_ubuntu_ce_sha256: e275717da0c22efb846b397a1ffeaf63a21ec91e4e481efe3b59de0a0d530982
+couchbase_server_ubuntu_ce_sha256: 237b530643bb6c7bc2fd36363a235957b4f6ac9558e50ba5b1dad094b8a50883
+
+# couchbase_server_ubuntu_ce_version: 4.0.0
+# couchbase_server_ubuntu_ce_package: couchbase-server-community_{{ couchbase_server_ubuntu_ce_version }}-ubuntu14.04_amd64.deb
+# couchbase_server_ubuntu_ce_url: http://packages.couchbase.com/releases/{{ couchbase_server_ubuntu_ce_version }}/{{ couchbase_server_ubuntu_ce_package }}
+# couchbase_server_ubuntu_ce_sha256: e275717da0c22efb846b397a1ffeaf63a21ec91e4e481efe3b59de0a0d530982
 
 # couchbase_server_ubuntu_ce_version: 3.0.1
 # couchbase_server_ubuntu_ce_package: couchbase-server-community_{{ couchbase_server_ubuntu_ce_version }}-ubuntu12.04_amd64.deb

--- a/defaults/Ubuntu.yml
+++ b/defaults/Ubuntu.yml
@@ -20,10 +20,15 @@
 #
 #############################################################################
 
-couchbase_server_ubuntu_ee_version: 4.1.1
+couchbase_server_ubuntu_ee_version: 4.5.1
 couchbase_server_ubuntu_ee_package: couchbase-server-enterprise_{{ couchbase_server_ubuntu_ee_version }}-ubuntu14.04_amd64.deb
 couchbase_server_ubuntu_ee_url: http://packages.couchbase.com/releases/{{ couchbase_server_ubuntu_ee_version }}/{{ couchbase_server_ubuntu_ee_package }}
-couchbase_server_ubuntu_ee_sha256: 65c0ee37f0e6d816257b32a36207ec9b8e81c84112beb657c851f9aacb9b4382
+couchbase_server_ubuntu_ee_sha256: 4e9075643a46c015acd2dbb5c7d6c047904b21c1934f4c53fbd1dd5d73c74c82
+
+# couchbase_server_ubuntu_ee_version: 4.1.1
+# couchbase_server_ubuntu_ee_package: couchbase-server-enterprise_{{ couchbase_server_ubuntu_ee_version }}-ubuntu14.04_amd64.deb
+# couchbase_server_ubuntu_ee_url: http://packages.couchbase.com/releases/{{ couchbase_server_ubuntu_ee_version }}/{{ couchbase_server_ubuntu_ee_package }}
+# couchbase_server_ubuntu_ee_sha256: 65c0ee37f0e6d816257b32a36207ec9b8e81c84112beb657c851f9aacb9b4382
 
 # couchbase_server_ubuntu_ee_version: 4.1.0
 # couchbase_server_ubuntu_ee_package: couchbase-server-enterprise_{{ couchbase_server_ubuntu_ee_version }}-ubuntu14.04_amd64.deb


### PR DESCRIPTION
This is a quick update of enterprise and community versions:
Version 4.5.1 for the enterprise version
Version 4.1.1 for the community version

Please, let me know if anything is missing to be able to update repository and update ansible galaxy?