### PR TITLE
Make role Couchbase 6.0 compatible

### DIFF
--- a/tasks/configure/audit.yml
+++ b/tasks/configure/audit.yml
@@ -1,4 +1,11 @@
 ---
+- name: Make sure audit log dir exists
+  file:
+    path: "{{ couchbase_audit.log_path | default('/opt/couchbase/var/lib/couchbase/logs') }}"
+    state: directory
+    owner: couchbase
+    group: couchbase
+
 # Docs: https://docs.couchbase.com/server/current/cli/cbcli/couchbase-cli-setting-audit.html
 - name: Set the Couchbase Audit Configuration
   shell:
@@ -10,8 +17,8 @@
         --audit-enabled {{ couchbase_audit.enabled | default(true) | int }} \
         --audit-log-rotate-interval {{ couchbase_audit.log_rotate_interval | default(86400) | int }} \
         --audit-log-rotate-size {{ couchbase_audit.log_rotate_size | default(20971520) | int }} \
-        --audit-log-path '{{ couchbase_audit.log_path | default('/opt/couchbase/var/lib/couchbase/logs') }}' \
-        --set
+        --audit-log-path '{{ couchbase_audit.log_path | default('/opt/couchbase/var/lib/couchbase/logs') }}'{% if couchbase_server_version is version_compare('6.5.1', '>=') %}\
+        --set{% endif %}
   when: couchbase_master is defined and couchbase_master == inventory_hostname
   tags:
     - couchbase_configure

--- a/tasks/configure/autofailover.yml
+++ b/tasks/configure/autofailover.yml
@@ -12,8 +12,9 @@
           --enable-failover-of-server-groups {{ couchbase_autofailover.failover_of_server_groups | default(false) | int }} \
           --enable-failover-on-data-disk-issues {{ couchbase_autofailover.failover_on_data_disk_issues | default(falfse) | int }} \
           --failover-data-disk-period {{ couchbase_autofailover.failover_data_disk_period | default(120) | int }} \
-          --max-failovers {{ couchbase_autofailover.max_failovers | default(1) | int }} \
+          --max-failovers {{ couchbase_autofailover.max_failovers | default(1) | int }}{% if couchbase_server_version is version_compare('6.5', '>=') %}\
           --can-abort-rebalance {{ couchbase_autofailover.can_abort_rebalance | default(true) | int }} \
+        {% endif %}
         {% endif %}
         --enable-auto-failover {{ couchbase_autofailover.enabled | default(false) | int }}
   when: couchbase_master is defined and couchbase_master == inventory_hostname and couchbase_server_edition == 'enterprise'

--- a/tasks/configure/buckets.yml
+++ b/tasks/configure/buckets.yml
@@ -21,8 +21,9 @@
           --bucket-priority {{ item.priority | default('low') }} \
           --bucket-eviction-policy {{ item.eviction_policy | default('valueOnly') }} \
           --conflict-resolution {{ item.conflict_resolution | default('sequence') }} \
-          --enable-flush {{ item.flush | default(false) | int }} \
+          --enable-flush {{ item.flush | default(false) | int }}{% if couchbase_server_version is version_compare('6.6', '>=') %}\
           --durability-min-level {{ item.durability_min_level | default('none') }} \
+          {% endif %}
           --compression-mode {{ item.compression_mode | default('passive') }} \
           --max-ttl {{ item.max_ttl | default(0) }} \
           --enable-index-replica {{ item.enable_index_replica | default(false) | int }} \

--- a/tasks/configure/initialize_nodes.yml
+++ b/tasks/configure/initialize_nodes.yml
@@ -1,4 +1,12 @@
 ---
+- name: Make sure required dirs exist
+  file:
+    path: "{{ item.value }}"
+    state: directory
+    owner: couchbase
+    group: couchbase
+  loop: "{{ couchbase_paths | dict2items }}"
+
 # Docs: https://docs.couchbase.com/server/current/cli/cbcli/couchbase-cli-node-init.html
 - name: Initialize the Node
   shell:
@@ -17,8 +25,8 @@
           --node-init-hostname '{{ item.hostname }}' \
           --node-init-data-path '{{ couchbase_paths.data }}' \
           --node-init-index-path '{{ couchbase_paths.index }}' \
-          --node-init-analytics-path '{{ couchbase_paths.analytics }}' \
-          --node-init-eventing-path '{{ couchbase_paths.eventing }}'
+          {% if couchbase_server_version is version_compare('6.5', '>=') %}--node-init-eventing-path '{{ couchbase_paths.eventing }}'{% endif %} \
+          --node-init-analytics-path '{{ couchbase_paths.analytics }}'
       fi
   with_items: "{{ couchbase_nodes }}"
   when: couchbase_master is defined

--- a/tasks/configure/password_policy.yml
+++ b/tasks/configure/password_policy.yml
@@ -8,10 +8,10 @@
         --username {{ couchbase_security.admin_user | default('Administrator') }} \
         --password '{{ couchbase_security.admin_password | default('password') }}' \
         --min-length {{ couchbase_password_policy.min_length | default(6) | int }} \
-        --uppercase {{ couchbase_password_policy.uppercase | default(false) | int }} \
-        --lowercase {{ couchbase_password_policy.lowercase | default(false) | int }} \
-        --digit {{ couchbase_password_policy.digit | default(false) | int }} \
-        --special-char {{ couchbase_password_policy.special_char | default(false) | int }} \
+        --uppercase {% if couchbase_server_version is version_compare('6.5.1', '>=') %}{{ couchbase_password_policy.uppercase | default(false) | int }}{% endif %}\
+        --lowercase {% if couchbase_server_version is version_compare('6.5.1', '>=') %}{{ couchbase_password_policy.lowercase | default(false) | int }}{% endif %}\
+        --digit {% if couchbase_server_version is version_compare('6.5.1', '>=') %}{{ couchbase_password_policy.digit | default(false) | int }}{% endif %}\
+        --special-char {% if couchbase_server_version is version_compare('6.5.1', '>=') %}{{ couchbase_password_policy.special_char | default(false) | int }}{% endif %}\
         --set
   when: couchbase_master is defined and couchbase_master == inventory_hostname
   tags:

--- a/tasks/configure/query_settings.yml
+++ b/tasks/configure/query_settings.yml
@@ -17,7 +17,7 @@
         --log-level {{ couchbase_query_settings.log_level | default('info') }} \
         --max-parallelism {{ couchbase_query_settings.max_parallelism | default(1) | int }} \
         --set
-  when: couchbase_master is defined and couchbase_master == inventory_hostname
+  when: couchbase_master is defined and couchbase_master == inventory_hostname and couchbase_server_version is version_compare('6.5', '>=')
   tags:
     - couchbase_configure
     - couchbase_query_settings

--- a/tasks/configure/rebalance_settings.yml
+++ b/tasks/configure/rebalance_settings.yml
@@ -14,7 +14,7 @@
           --moves-per-node {{ couchbase_rebalance_settings.moves_per_node | default(4) | int }} \
         {% endif %}
         --set
-  when: couchbase_master is defined and couchbase_master == inventory_hostname
+  when: couchbase_master is defined and couchbase_master == inventory_hostname and couchbase_server_version is version_compare('6.5', '>=')
   tags:
     - couchbase_configure
     - couchbase_rebalance_settings

--- a/tasks/configure/security_settings.yml
+++ b/tasks/configure/security_settings.yml
@@ -7,11 +7,11 @@
         --cluster {{ inventory_hostname }} \
         --username {{ couchbase_security.admin_user | default('Administrator') }} \
         --password '{{ couchbase_security.admin_password | default('password') }}' \
-        --disable-http-ui {{ couchbase_security.disable_http_ui | default(false) | int }} \
+        --disable-http-ui {{ couchbase_security.disable_http_ui | default(false) | int }}{% if couchbase_server_version is version_compare('6.5', '>=') %}\
         --disable-www-authenticate {{ couchbase_security.disable_www_authenticate | default(false) | int }} \
         --tls-min-version {{ couchbase_security.tls_min_version | default('tlsv1') }} \
         --tls-honor-cipher-order {{ couchbase_security.tls_honor_cipher_order | default(true) | int }} \
-        --set
+        --set{% endif %}
   when: couchbase_master is defined and couchbase_master == inventory_hostname
   tags:
     - couchbase_configure

--- a/tasks/install/ubuntu.yml
+++ b/tasks/install/ubuntu.yml
@@ -30,6 +30,8 @@
       sed -E 's/^couchbase-server[^ ]+\s+|\s+.+//g'
   register: couchbase_latest_version
   become: true
+  args:
+    executable: /bin/bash
   when: ((couchbase_server_download_url is defined) and (couchbase_server_download_url | length == 0)) and couchbase_server_version == 'latest'
   tags:
     - couchbase_install

--- a/tasks/preflight/buckets.yml
+++ b/tasks/preflight/buckets.yml
@@ -56,7 +56,7 @@
 - name: Fail when the buckets[*] has a conflict_resolution property has been set but is invalid
   fail:
     msg: "The buckets[*] 'conflict_resolution' property must be: sequence or timestamp"
-  when: ( item.eviction_policy is defined and item.eviction_policy not in ['sequence', 'timestamp'] )
+  when: ( item.conflict_resolution is defined and item.conflict_resolution not in ['sequence', 'timestamp'] )
   with_items: "{{ couchbase_buckets }}"
   tags:
     - couchbase_configure
@@ -65,7 +65,7 @@
 - name: Fail when the buckets[*] has a compression_mode property has been set but is invalid
   fail:
     msg: "The buckets[*] 'compression_mode' property must be: off, passive, active"
-  when: ( item.eviction_policy is defined and item.eviction_policy not in ['off', 'passive', 'active'] )
+  when: ( item.compression_mode is defined and item.compression_mode not in ['off', 'passive', 'active'] )
   with_items: "{{ couchbase_buckets }}"
   tags:
     - couchbase_configure


### PR DESCRIPTION
Due to many incompatibilities it is impossible to use this role for Couchbase 6.0 even it is still available in repository. This PR is adding version checking to some commands.