### PR TITLE
Respect couchbase_server_edition variable

### DIFF
--- a/tasks/configure/audit.yml
+++ b/tasks/configure/audit.yml
@@ -12,7 +12,7 @@
         --audit-log-rotate-size {{ couchbase_audit.log_rotate_size | default(20971520) | int }} \
         --audit-log-path '{{ couchbase_audit.log_path | default('/opt/couchbase/var/lib/couchbase/logs') }}' \
         --set
-  when: couchbase_master is defined and couchbase_master == inventory_hostname
+  when: couchbase_master is defined and couchbase_master == inventory_hostname and couchbase_server_edition == "enterprise"
   tags:
     - couchbase_configure
     - couchbase_audit

--- a/tasks/configure/rebalance_settings.yml
+++ b/tasks/configure/rebalance_settings.yml
@@ -14,7 +14,7 @@
           --moves-per-node {{ couchbase_rebalance_settings.moves_per_node | default(4) | int }} \
         {% endif %}
         --set
-  when: couchbase_master is defined and couchbase_master == inventory_hostname
+  when: couchbase_master is defined and couchbase_master == inventory_hostname and couchbase_server_edition == "enterprise"
   tags:
     - couchbase_configure
     - couchbase_rebalance_settings

--- a/tasks/configure/security_settings.yml
+++ b/tasks/configure/security_settings.yml
@@ -9,8 +9,10 @@
         --password '{{ couchbase_security.admin_password | default('password') }}' \
         --disable-http-ui {{ couchbase_security.disable_http_ui | default(false) | int }} \
         --disable-www-authenticate {{ couchbase_security.disable_www_authenticate | default(false) | int }} \
+        {% if couchbase_server_edition == "enterprise" %}
         --tls-min-version {{ couchbase_security.tls_min_version | default('tlsv1') }} \
         --tls-honor-cipher-order {{ couchbase_security.tls_honor_cipher_order | default(true) | int }} \
+        {% endif %}
         --set
   when: couchbase_master is defined and couchbase_master == inventory_hostname
   tags:

--- a/tasks/install/amazon.yml
+++ b/tasks/install/amazon.yml
@@ -38,7 +38,7 @@
 
 - name: Output the Build Version
   debug:
-    msg: "Using Couchbase Version: {{ couchbase_server_version }}"
+    msg: "Using Couchbase Version: {{couchbase_server_edition}} {{ couchbase_server_version }}"
   when: (couchbase_server_download_url is defined) and (couchbase_server_download_url | length == 0)
   tags:
     - couchbase_install
@@ -46,7 +46,7 @@
 
 - name: Install Couchbase Server package
   yum:
-    name: "couchbase-server-{{ couchbase_server_version }}"
+    name: "couchbase-server{% if couchbase_server_edition == "community" %}-community{% endif %}-{{ couchbase_server_version }}"
     state: present
   when: (couchbase_server_download_url is defined) and (couchbase_server_download_url | length == 0)
   tags:

--- a/tasks/install/redhat.yml
+++ b/tasks/install/redhat.yml
@@ -38,7 +38,7 @@
 
 - name: Output the Build Version
   debug:
-    msg: "Using Couchbase Version: {{ couchbase_server_version }}"
+    msg: "Using Couchbase Version: {{couchbase_server_edition}} {{ couchbase_server_version }}"
   when: (couchbase_server_download_url is defined) and (couchbase_server_download_url | length == 0)
   tags:
     - couchbase_install
@@ -46,7 +46,7 @@
 
 - name: Install Couchbase Server package
   yum:
-    name: "couchbase-server-{{ couchbase_server_version }}"
+    name: "couchbase-server{% if couchbase_server_edition == "community" %}-community{% endif %}-{{ couchbase_server_version }}"
     state: present
   when: (couchbase_server_download_url is defined) and (couchbase_server_download_url | length == 0)
   tags:

--- a/tasks/install/ubuntu.yml
+++ b/tasks/install/ubuntu.yml
@@ -43,15 +43,15 @@
 
 - name: Output the Build Version
   debug:
-    msg: "Using Couchbase Version: {{ couchbase_server_version }}"
-  when: (couchbase_server_download_url is defined) and (couchbase_server_download_url | length == 0)
+    msg: "Using Couchbase Version: {{couchbase_server_edition}} {{ couchbase_server_version }}"
+  when: (couchbase_server_download_url is defined) and (couchbase_server_download_url | length == 0) 
   tags:
     - couchbase_install
     - couchbase_debug
 
 - name: Install Couchbase Server package
   apt:
-    name: "couchbase-server={{ couchbase_server_version }}"
+    name: "couchbase-server{% if couchbase_server_edition == "community" %}-community{% endif %}={{ couchbase_server_version }}"
     state: present
   when: (couchbase_server_download_url is defined) and (couchbase_server_download_url | length == 0)
   tags:

--- a/tasks/install/ubuntu.yml
+++ b/tasks/install/ubuntu.yml
@@ -44,7 +44,7 @@
 - name: Output the Build Version
   debug:
     msg: "Using Couchbase Version: {{couchbase_server_edition}} {{ couchbase_server_version }}"
-  when: (couchbase_server_download_url is defined) and (couchbase_server_download_url | length == 0) 
+  when: (couchbase_server_download_url is defined) and (couchbase_server_download_url | length == 0)
   tags:
     - couchbase_install
     - couchbase_debug


### PR DESCRIPTION
This pull request fixes a bug when even though `couchbase_server_edition`  variable is set to "community", playbook still installs enterprise Couchbase package.

Additionally, configuring of some features were disabled for community version which are not applicable to it.