### PR TITLE
Skip task when 'Group 1' not exists

### DIFF
--- a/tasks/configure/server_groups.yml
+++ b/tasks/configure/server_groups.yml
@@ -39,6 +39,10 @@
   tags:
     - couchbase_configure
     - couchbase_server_groups
+  register: result
+  failed_when:
+    - result.rc == 1
+    - '"not found" not in result.stdout'
 
 - name: Remove Default Group ('Group 1') if not used
   shell:


### PR DESCRIPTION
Make role more idempotent and skip task when `Group 1` is removed (in later task).